### PR TITLE
sakura sonic E2 activation timing missing FIX

### DIFF
--- a/script/c210660397.lua
+++ b/script/c210660397.lua
@@ -75,9 +75,12 @@ function s.coin_operation(e,tp,eg,ep,ev,re,r,rp)
 end
 -- Effect 2 Functions
 function s.discard_condition(e,tp,eg,ep,ev,re,r,rp)
-    return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)>=2 and
-           Duel.GetFieldGroupCount(tp,0,LOCATION_HAND+LOCATION_ONFIELD) >
-           Duel.GetFieldGroupCount(tp,LOCATION_HAND+LOCATION_ONFIELD,0)
+    local phase=Duel.GetCurrentPhase()
+    return (Duel.IsMainPhase() and tp==Duel.GetTurnPlayer()) -- Main Phase
+        or (Duel.IsBattlePhase() and tp~=Duel.GetTurnPlayer()) -- Opponent's Battle Phase
+        and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)>=2
+        and Duel.GetFieldGroupCount(tp,0,LOCATION_HAND+LOCATION_ONFIELD) >
+        Duel.GetFieldGroupCount(tp,LOCATION_HAND+LOCATION_ONFIELD,0)
 end
 function s.discard_cost(e,tp,eg,ep,ev,re,r,rp,chk)
     if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)>=2 end


### PR DESCRIPTION
im sure i did script this correctly before idk why it gone :Derp: Reminder to update sakura sonic e1 text to gains 1800 attack untill the end of this turn